### PR TITLE
Makes PDF generation manually triggered

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: ci
+name: Documentation Site CI
 on:
   push:
     branches:

--- a/.github/workflows/generate-pdf.yml
+++ b/.github/workflows/generate-pdf.yml
@@ -1,10 +1,5 @@
 name: Generate CIM Modeling Guide PDF
-on:
-  push:
-  release:
-    types: [published]
-  pull_request:
-    branches: [ "master" ]
+on: workflow_dispatch
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This change makes the Modeling Guide PDF generation happen via a manual GitHub Action.