### PR TITLE
Fixes issue with CIM Modeling Guide PDF missing pages

### DIFF
--- a/.github/workflows/generate-pdf.yml
+++ b/.github/workflows/generate-pdf.yml
@@ -5,23 +5,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout this repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install/setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.x
+        python-version: 3.9
     - name: Install mkdocs documentation tool
-      run: pip install mkdocs-material
-    - name: Install PDF export plugin dependency (Pango)
-      run: sudo apt install libpango-1.0-0 libharfbuzz0b libpangoft2-1.0-0
-    - name: Install PDF export plugin for mkdocs
-      run: pip install mkdocs-pdf-export-plugin
+      run: pip install mkdocs-material mkdocs-with-pdf
     - name: Build the documentation including PDF
       run: mkdocs build
-      env:
-        ENABLE_PDF_EXPORT: 1
     - name: Upload CIM Modeling Guide PDF as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: CIM_Modeling_Guide.pdf
-        path: site/CIM_Modeling_Guide.pdf
+        path: site/pdf/document.pdf

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,10 +18,15 @@ markdown_extensions:
   - pymdownx.details
 plugins:
   - search
-  - pdf-export:
-      enabled_if_env: ENABLE_PDF_EXPORT
-      combined: true
-      combined_output_path: CIM_Modeling_Guide.pdf
+  - with-pdf:
+      copyright: CIMug Users Group
+      cover: true
+      cover_title: CIM Users Group
+      cover_subtitle: CIM Modeling Guide
+      toc_title: Table of Contents
+      heading_shift: true
+      toc_level: 3
+      show_anchors: true
 nav:
   - 'index.md'
   - 'section1-introduction.md'


### PR DESCRIPTION
The CIM Modeling Guide PDF was missing some pages when using the mkdocs-pdf-export-plugin so switched to https://github.com/orzih/mkdocs-with-pdf. The PDF generation GitHub Action has been updated accordingly and also increased the GitHub Action module versions.