### PR TITLE
Improves build speed of site by making PDF generation conditional

### DIFF
--- a/.github/workflows/generate-pdf.yml
+++ b/.github/workflows/generate-pdf.yml
@@ -14,8 +14,10 @@ jobs:
       run: pip install mkdocs-material mkdocs-with-pdf
     - name: Build the documentation including PDF
       run: mkdocs build
+      env:
+        ENABLE_PDF_EXPORT: 1
     - name: Upload CIM Modeling Guide PDF as artifact
       uses: actions/upload-artifact@v4
       with:
         name: CIM_Modeling_Guide.pdf
-        path: site/pdf/document.pdf
+        path: site/pdf/CIM_Modeling_Guide.pdf

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,8 @@ plugins:
       heading_shift: true
       toc_level: 3
       show_anchors: true
+      enabled_if_env: ENABLE_PDF_EXPORT
+      output_path: pdf/CIM_Modeling_Guide.pdf
 nav:
   - 'index.md'
   - 'section1-introduction.md'


### PR DESCRIPTION
Generating the CIM Modeling Guide PDF is a relatively time consuming operation (5-7 seconds) that slows down quick re-rendering of the website when making edits and serving local instance using `mkdocs serve`. This commit makes PDF conditional using an environment variable to making editing smoother and faster.