### PR TITLE
Adds GitHub Action to publish v1.1 https://cim-mg.ucaiug.io site

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -1,0 +1,22 @@
+name: Publish website
+on: workflow_dispatch
+permissions:
+  contents: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout this repository
+      uses: actions/checkout@v4
+    - name: Install/setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.9
+    - name: Install mkdocs documentation tool and plugins
+      run: pip install -r requirements.txt
+    - name: Configure Deploy
+      run: |
+        git config --global user.name "Admin CIMug"
+        git config --global user.email "cimug.dev@gmail.com"
+    - name: Build Docs Website
+      run: mike deploy --branch gh-pages --push 1.1


### PR DESCRIPTION
Adds GitHub Action that you can run manually as needed to publish version 1.1 of the https://cim-mg.ucaiug.io/ website. This isn't done autmomatically on merge but rather only manually/on-demand by navigating to the "GitHub Action" tab of the repo and running. This is manual so that that the CIM Modeling Guide maintainers have full control over when new versions get published.