### PR TITLE
Adds GitHub Action to publish https://cim-mg.ucaiug.io site

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -1,0 +1,18 @@
+name: Publish website
+on: workflow_dispatch
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout this repository
+      uses: actions/checkout@v4
+    - name: Install/setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.9
+    - name: Install mkdocs documentation tool and plugins
+      run: pip install -r requirements.txt
+    - name: Configure Deploy
+      run: |
+        git config --global user.name "Admin CIMug"
+        git config --global user.email "cimug.dev@gmail.com"


### PR DESCRIPTION
Adds GitHub Action that you can to publish versions of the https://cim-mg.ucaiug.io website. This isn't done autmomatically on merge but rather manually/on-demand by navigating to the "GitHub Action" tab of the repo and running it. This is manual so that the CIM Modeling Guide maintainers have full control over when new versions get published. Note that this action on master doesn't actually publish because the "master" branch is considered in development and must not be visible until a new version is ready. However, this GitHub Action is needed on master so that users can still select it via the GitHub user interface and so that it is ready once a new version (e.g. 2.0) needs to be published.