### PR TITLE
Updates PDF color styling

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ plugins:
       ordered_chapter_level: 0
       toc_level: 3
       show_anchors: true
+      enabled_if_env: ENABLE_PDF_EXPORT
       output_path: pdf/CIM_Modeling_Guide.pdf
   # This 'mike' plugin is for publishing multiple versions see https://github.com/jimporter/mike
   - mike: 

--- a/templates/styles.scss
+++ b/templates/styles.scss
@@ -1,0 +1,11 @@
+article h1 {
+    border-bottom: 2px solid #009dab;
+}
+
+article h2 {
+    border-bottom: 1px solid #009dab;
+}
+
+.md-typeset a {
+    color: #0b57d0;
+}


### PR DESCRIPTION
The default color styling used for the PDF included red underlines and a light grey color for hyperlinks which made them hard to see. This update changes the red underlines to use CIM color scheme (#009dab) and changes hyperlinks to familiar blue color.