### PR TITLE
Updates PDF color formatting v1.1

### DIFF
--- a/templates/styles.scss
+++ b/templates/styles.scss
@@ -1,0 +1,11 @@
+article h1 {
+    border-bottom: 2px solid #009dab;
+}
+
+article h2 {
+    border-bottom: 1px solid #009dab;
+}
+
+.md-typeset a {
+    color: #0b57d0;
+}


### PR DESCRIPTION
The default color scheme used for the PDF included red underlines and a light grey color for hyperlinks which made them hard to see. This update changes the red underlines to use CIM color scheme (#009dab) and changes hyperlinks to familiar blue color.