### PR TITLE
Adds gh-pages checkout to site publish workflow

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -8,15 +8,20 @@ jobs:
     steps:
     - name: Checkout this repository
       uses: actions/checkout@v4
+
     - name: Install/setup Python
       uses: actions/setup-python@v5
       with:
         python-version: 3.9
+
     - name: Install mkdocs documentation tool and plugins
       run: pip install -r requirements.txt
+
     - name: Configure Deploy
       run: |
         git config --global user.name "Admin CIMug"
         git config --global user.email "cimug.dev@gmail.com"
+        git fetch origin gh-pages --depth=1
+
     - name: Build Docs Website
-      run: mike deploy --branch gh-pages --push 1.1
+      run: mike deploy --branch gh-pages --remote origin --push 1.1


### PR DESCRIPTION
The GitHub Action workflow for publishing the site was failing. This is due to the gh-pages branch not getting checked out on GitHub Action runs. It does not get checked out because by default the actions/checkout@v4 step does a very lightweight checkout (i.e. only current branch with depth of 1). This commit adds a fetch of the gh-pages branch so that the branch is checked out and the publish step does not report missing remote changes.